### PR TITLE
Feature: attach delay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.11"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d646c7ade5eb07c4aa20e907a922750df0c448892513714fd3e4acbc7130829f"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.7"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -977,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 bytes = "1.2.0"
-clap = { version = "3.1.18", features = ["derive"] }
+clap = { version = "3.2.22", features = ["derive"] }
 futures = "0.3.21"
 id-pool = { version = "0.2.2", default-features = false, features = ["u16"] }
 prometheus-client = "0.17.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,13 +48,21 @@ pub struct Config {
     #[clap(long, parse(try_from_str = parse_ports), value_name = "START:END", default_value = "9001:9999")]
     pub tcpports: Range<u16>,
 
-    /// Connect to child using TCP instead of stdio
+    /// Connect to child using TCP instead of stdio. Use PORT to bind
     #[clap(long, action)]
     pub tcp: bool,
 
     /// Increase level of verbosity
     #[clap(short, parse(from_occurrences))]
     pub verbosity: usize,
+
+    /// Delay before attaching to child [default: 1 for --tcp]
+    #[clap(
+        long,
+        value_name = "SECONDS",
+        default_value_if("tcp", Some("true"), Some("1"))
+    )]
+    pub cmd_attach_delay: Option<u64>,
 
     /// Command to wrap
     #[clap(required = true)]


### PR DESCRIPTION
* Add `--cmd-attach-delay` argument for delaying attaching to child process.
* Update dependency clap