### PR TITLE
Feature: message framing and routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 !Cargo.*
 !README.md
 !LICENSE
-!src
+!src/**/*.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,6 +559,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +821,8 @@ dependencies = [
  "clap",
  "futures",
  "id-pool",
+ "num-derive",
+ "num-traits",
  "prometheus-client",
  "sender-sink",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,9 +828,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sender-sink"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9904789a825a79b5329502029f9cb73e9d4da8ea531f0e69c357d6d5c9b092d6"
+checksum = "2b83a4d5ddaf7f8f705370014d280bb17cc809d04fef967d82d685f3a5dba4a9"
 dependencies = [
  "futures",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ clap = { version = "3.2.22", features = ["derive"] }
 futures = "0.3.21"
 id-pool = { version = "0.2.2", default-features = false, features = ["u16"] }
 prometheus-client = "0.17.0"
-sender-sink = "0.1.0"
+sender-sink = "0.2.0"
 serde_json = "1.0.81"
 thiserror = "1.0.31"
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ bytes = "1.2.0"
 clap = { version = "3.2.22", features = ["derive"] }
 futures = "0.3.21"
 id-pool = { version = "0.2.2", default-features = false, features = ["u16"] }
+num-traits = "0.2"
+num-derive = "0.3"
 prometheus-client = "0.17.0"
 sender-sink = "0.2.0"
 serde_json = "1.0.81"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 * Share a backend process between clients
 * Proxy websocket traffic to normal TCP socket or stdio
+* Route server messages to specific clients
 * Serve static files
 * Expose CGI [environment variables](https://www.rfc-editor.org/rfc/rfc3875.html) to backend process
 * [OpenMetrics](https://github.com/OpenObservability/OpenMetrics) compatible

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -33,7 +33,7 @@ pub enum Source {
 
 impl Channel {
     pub fn new(config: &Config, port: Option<PortID>, env: CGIEnv) -> Self {
-        let (tx, rx) = mpsc::unbounded_channel::<Bytes>();
+        let (tx, rx) = mpsc::unbounded_channel::<Message>();
         let (cast_tx, _) = broadcast::channel(16);
         let (kill_tx, kill_rx) = oneshot::channel();
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,6 +38,14 @@ pub struct Config {
     pub passenv: Vec<String>,
 
     /// Enable framing and routing for messages
+    ///
+    /// Client messages are amended with ID header. Server messages with optional client ID routed to clients.
+    ///
+    /// When set to `json` messages are parsed as JSON. Client messages are amended with an "id" field. Server messages are routed to clients based an optional "id" field.
+    /// When set to `binary` messages are parsed according to gwsocket's strict mode.
+    /// Unparseable messages are dropped.
+    ///
+    /// [default: binary when set, possible values: binary, json]
     #[clap(
         long,
         alias = "strict",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::types::Framing;
 use {clap::Parser, std::net::SocketAddr, std::ops::Range, std::path::PathBuf};
 
 #[derive(Parser, Debug, Clone)]
@@ -35,6 +36,19 @@ pub struct Config {
         default_value = "PATH,DYLD_LIBRARY_PATH"
     )]
     pub passenv: Vec<String>,
+
+    /// Enable framing and routing for messages
+    #[clap(
+        long,
+        alias = "strict",
+        value_parser,
+        value_name = "MODE",
+        default_missing_value = "binary",
+        min_values = 0,
+        require_equals = true,
+        hide_possible_values = true
+    )]
+    pub frame: Option<Framing>,
 
     /// Serve static files from directory over HTTP
     #[clap(long, value_parser, value_name = "DIR")]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::{AppError, AppResult},
-    message::encode,
+    message::serialize,
     types::{ConnID, Framing, FromProcessRx, ToProcessTx},
 };
 
@@ -33,9 +33,9 @@ pub async fn handle(
         .filter_map(|line| ready(line.ok()))
         .filter_map(|(id, msg)| {
             ready(match id {
-                // message is to us
+                // message is routed to us
                 Some(id) if id == conn => Some(msg),
-                // message is not to us
+                // message is not routed to us
                 Some(_) => None,
                 // message is broadcast
                 None => Some(msg),
@@ -52,7 +52,7 @@ pub async fn handle(
             let result = sock_rx
                 .try_take_while(|msg| ready(Ok(!msg.is_close())))
                 .filter_map(|line| ready(line.ok()))
-                .map(|msg| encode(msg, conn, framing))
+                .map(|msg| serialize(msg, conn, framing))
                 .forward(proc_tx_sink)
                 .await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,9 @@ mod signal;
 mod types;
 mod utils;
 
+#[macro_use]
+extern crate num_derive;
+
 use crate::{cli::Config, logging::setup_logging, metrics::Metrics, types::Event};
 
 use {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod envvars;
 mod error;
 mod events;
 mod logging;
+mod message;
 mod metrics;
 mod process;
 mod routes;

--- a/src/message.rs
+++ b/src/message.rs
@@ -147,6 +147,19 @@ mod tests {
         let (result, _, _, _) = parse_binary_header(&payload);
         assert_eq!(result, Some(123));
     }
+
+    #[test]
+    fn test_parse_id_0_is_broadcast() {
+        let payload = [
+            (0 as u32).to_le_bytes(),
+            (0 as u32).to_le_bytes(),
+            (0 as u32).to_le_bytes(),
+        ]
+        .concat();
+        let (result, _, _, _) = parse_binary_header(&payload);
+        assert_eq!(result, None);
+    }
+
     #[test]
     fn test_parse_type() {
         let payload = [

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,8 +1,11 @@
 use serde_json::Value;
 
 use crate::types::{ConnID, Framing};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
 use {bytes::Bytes, sender_sink::wrappers::SinkError, warp::ws::Message};
 
+/// An extension trait for `Message`s that provides routing helpers
 pub trait Address<T> {
     fn to(self, to: usize) -> (Option<usize>, T);
     fn to_some(self, to: Option<usize>) -> (Option<usize>, Message);
@@ -23,24 +26,45 @@ impl Address<Message> for Message {
     }
 }
 
-pub fn decode(msg: &Bytes, framing: Option<Framing>) -> Option<ConnID> {
+pub fn deserialize(
+    msg: &Bytes,
+    framing: Option<Framing>,
+) -> Result<(Option<ConnID>, &[u8]), &'static str> {
     match framing {
-        Some(mode) => match mode {
-            Framing::Binary => todo!(),
-            Framing::JSON => match serde_json::from_slice::<Value>(&msg) {
-                Ok(ref payload) => payload
-                    .get("id")
-                    .and_then(|v: &Value| v.as_u64())
-                    // TODO may truncate
-                    .and_then(|v: u64| usize::try_from(v).ok()),
-                _ => None,
-            },
-        },
-        None => None,
+        Some(mode) => {
+            match mode {
+                Framing::Binary => {
+                    let (id, msg_type, length, payload) = parse_binary_header(msg);
+                    let effective_len = payload.len();
+                    let header_len = length as usize;
+
+                    assert_eq!(
+                        effective_len, header_len as usize,
+                        "Message length {} does not match {}: Chunked payloads are not supported",
+                        effective_len, header_len
+                    );
+
+                    match msg_type {
+                        Some(Type::Binary) => Ok((id, payload)),
+                        Some(Type::Text) => Ok((id, payload)),
+                        None => Err("Unknown message type"),
+                    }
+                }
+                Framing::JSON => {
+                    let (id, msg) = parse_json_header(msg);
+                    Ok((id, msg))
+                }
+            }
+        }
+        None => Ok((None, msg)),
     }
 }
 
-pub fn encode(msg: Message, conn: ConnID, framing: Option<Framing>) -> Result<Message, SinkError> {
+pub fn serialize(
+    msg: Message,
+    conn: ConnID,
+    framing: Option<Framing>,
+) -> Result<Message, SinkError> {
     match framing {
         Some(mode) => match mode {
             Framing::Binary => todo!(),
@@ -60,5 +84,90 @@ pub fn encode(msg: Message, conn: ConnID, framing: Option<Framing>) -> Result<Me
             },
         },
         None => Ok(msg),
+    }
+}
+
+#[derive(FromPrimitive, ToPrimitive, Debug, PartialEq)]
+pub enum Type {
+    Text = 1,
+    Binary = 2,
+}
+
+pub fn parse_json_header(msg: &Bytes) -> (Option<ConnID>, &[u8]) {
+    let id = match serde_json::from_slice::<Value>(msg) {
+        Ok(ref payload) => payload
+            .get("id")
+            .and_then(|v: &Value| v.as_u64())
+            .and_then(|v: u64| usize::try_from(v).ok()),
+        _ => None,
+    };
+    (id, msg)
+}
+
+/// Parse fixed-length 12 byte header consisting of three u32 values in network byte order.
+///
+/// The header consists of the routing ID, message type and payload length.
+/// Message type is 1 for text and 2 for binary.
+pub fn parse_binary_header(data: &[u8]) -> (Option<ConnID>, Option<Type>, u32, &[u8]) {
+    let mut id_data = [0; 4];
+    id_data.copy_from_slice(&data[0..4]);
+
+    let id = usize::try_from(u32::from_le_bytes(id_data)).expect("u32 to fit in usize");
+    let id = match id {
+        // message is broadcast
+        0 => None,
+        // message is routed
+        id => Some(id),
+    };
+
+    let mut msg_type_data = [0; 4];
+    msg_type_data.copy_from_slice(&data[4..8]);
+    let msg_type = u32::from_le_bytes(msg_type_data);
+    let msg_type: Option<Type> = FromPrimitive::from_u32(msg_type);
+
+    let mut msg_len_data = [0; 4];
+    msg_len_data.copy_from_slice(&data[8..12]);
+    let msg_len = u32::from_le_bytes(msg_len_data);
+
+    (id, msg_type, msg_len, &data[12..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_binary_header, Type};
+
+    #[test]
+    fn test_parse_id() {
+        let payload = [
+            (123 as u32).to_le_bytes(),
+            (0 as u32).to_le_bytes(),
+            (0 as u32).to_le_bytes(),
+        ]
+        .concat();
+        let (result, _, _, _) = parse_binary_header(&payload);
+        assert_eq!(result, Some(123));
+    }
+    #[test]
+    fn test_parse_type() {
+        let payload = [
+            (0 as u32).to_le_bytes(),
+            (2 as u32).to_le_bytes(),
+            (0 as u32).to_le_bytes(),
+        ]
+        .concat();
+        let (_, result, _, _) = parse_binary_header(&payload);
+        assert_eq!(result, Some(Type::Binary));
+    }
+
+    #[test]
+    fn test_parse_length() {
+        let payload = [
+            (0 as u32).to_le_bytes(),
+            (0 as u32).to_le_bytes(),
+            (123 as u32).to_le_bytes(),
+        ]
+        .concat();
+        let (_, _, result, _) = parse_binary_header(&payload);
+        assert_eq!(result, 123);
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,0 +1,47 @@
+use serde_json::Value;
+
+use crate::types::{ConnID, Framing};
+use {sender_sink::wrappers::SinkError, warp::ws::Message};
+
+pub trait Address<T> {
+    fn to(self, to: usize) -> (Option<usize>, T);
+    fn to_some(self, to: Option<usize>) -> (Option<usize>, Message);
+    fn broadcast(self) -> (Option<usize>, T);
+}
+
+impl Address<Message> for Message {
+    fn to(self, to: usize) -> (Option<usize>, Message) {
+        (Some(to), self)
+    }
+
+    fn to_some(self, to: Option<usize>) -> (Option<usize>, Message) {
+        (to, self)
+    }
+
+    fn broadcast(self) -> (Option<usize>, Message) {
+        (None, self)
+    }
+}
+
+pub fn encode(msg: Message, conn: ConnID, framing: Option<Framing>) -> Result<Message, SinkError> {
+    match framing {
+        Some(mode) => match mode {
+            Framing::Binary => todo!(),
+            Framing::JSON => match serde_json::from_slice::<Value>(msg.as_bytes()) {
+                Ok(mut v) if v.is_object() => {
+                    v["id"] = Value::from(conn);
+                    Ok(Message::text(v.to_string()))
+                }
+                Ok(_) => {
+                    tracing::error!("bad data: message is not a JSON object");
+                    Err(SinkError::SendFailed)
+                }
+                Err(_) => {
+                    tracing::error!("bad data: message is not valid JSON");
+                    Err(SinkError::SendFailed)
+                }
+            },
+        },
+        None => Ok(msg),
+    }
+}

--- a/src/process.rs
+++ b/src/process.rs
@@ -262,6 +262,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_handle_process_output_framed_binary() {
+        let process = create_process(concat!(
+            "scalesocket --frame printf -- ",
+            "\\002\\000\\000\\000", // id
+            "\\001\\000\\000\\000", // type
+            "\\003\\000\\000\\000", // payload length
+            "abc",                  // payload
+            "\\n"
+        ));
+        let mut proc_rx = process.cast_tx.subscribe();
+
+        handle(process, None).await.ok();
+        let output = proc_rx.recv().await.ok();
+
+        assert_eq!(output, Some(Message::text("abc").to(2)));
+    }
+
+    #[tokio::test]
     async fn test_handle_process_input() {
         let process = create_process("scalesocket head -- -n 1");
         let mut proc_rx = process.cast_tx.subscribe();

--- a/src/types.rs
+++ b/src/types.rs
@@ -30,14 +30,20 @@ pub enum Event {
     Shutdown,
 }
 
+#[derive(Debug, clap::ValueEnum, Clone, Copy)]
+pub enum Framing {
+    JSON,
+    Binary,
+}
+
 // Channel for app events
 pub type EventTx = mpsc::UnboundedSender<Event>;
 pub type EventRx = mpsc::UnboundedReceiver<Event>;
 
 // Channel for passing data to child process
-pub type ToProcessTx = mpsc::UnboundedSender<Bytes>;
-pub type ToProcessRx = mpsc::UnboundedReceiver<Bytes>;
-pub type ToProcessRxStream = UnboundedReceiverStream<Bytes>;
+pub type ToProcessTx = mpsc::UnboundedSender<Message>;
+pub type ToProcessRx = mpsc::UnboundedReceiver<Message>;
+pub type ToProcessRxStream = UnboundedReceiverStream<Message>;
 
 // Channel for triggering shutdown of child process
 pub type ShutdownTx = oneshot::Sender<()>;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,5 @@
 use crate::envvars::Env;
 use {
-    bytes::Bytes,
     tokio::sync::{broadcast, mpsc, oneshot},
     tokio_stream::wrappers::UnboundedReceiverStream,
     warp::ws::{Message, WebSocket},
@@ -51,5 +50,5 @@ pub type ShutdownRx = oneshot::Receiver<()>;
 pub type ShutdownRxStream = futures::future::IntoStream<ShutdownRx>;
 
 // Channel for passing data to from child process
-pub type FromProcessTx = broadcast::Sender<Message>;
-pub type FromProcessRx = broadcast::Receiver<Message>;
+pub type FromProcessTx = broadcast::Sender<(Option<ConnID>, Message)>;
+pub type FromProcessRx = broadcast::Receiver<(Option<ConnID>, Message)>;

--- a/src/types.rs
+++ b/src/types.rs
@@ -52,3 +52,5 @@ pub type ShutdownRxStream = futures::future::IntoStream<ShutdownRx>;
 // Channel for passing data to from child process
 pub type FromProcessTx = broadcast::Sender<(Option<ConnID>, Message)>;
 pub type FromProcessRx = broadcast::Receiver<(Option<ConnID>, Message)>;
+
+pub type ProcessSenders = (FromProcessTx, ToProcessTx, ShutdownTx);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,17 +14,13 @@ pub fn new_conn_id() -> ConnID {
     NEXT_CONNECTION_ID.fetch_add(1, Ordering::Relaxed)
 }
 
-pub fn run<I, S>(
+pub fn run(
     program: &str,
-    args: I,
+    args: Vec<String>,
     port: Option<PortID>,
     env_extra: HashMap<String, String>,
     env_allowlist: &[String],
-) -> Command
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<std::ffi::OsStr>,
-{
+) -> Command {
     // Combine filtered environment with external variables
     let env: HashMap<String, String> = env::vars()
         .filter(|&(ref k, _)| env_allowlist.contains(k))


### PR DESCRIPTION
* Add `--framing` argument for specifying framing and routing.
  * When enabled, client messages are amended with ID header. Server messages with optional client ID routed to clients.
  * Possible values are `binary`, which is the default, and `json` by specifying `--framing=json`.
  * Binary framing implements the header specified by [gwsocket](https://gwsocket.io/man), while JSON framing uses payload `id` field.
  * Unframed client messages will be dropped. Eg. sending payload that is not JSON.
