### PR TITLE
Fix: use u32 for connection ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ OPTIONS:
         --frame[=<MODE>...]
             Enable framing and routing for messages
             
-            Client messages are amended with ID header. Server messages with optional client ID
-            routed to clients.
+            Client messages are amended with ID header (u32). Server messages with optional client
+            ID are routed to clients.
             
             When set to `json` messages are parsed as JSON. Client messages are amended with an "id"
             field. Server messages are routed to clients based an optional "id" field. When set to

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,7 +48,7 @@ pub struct Config {
 
     /// Enable framing and routing for messages
     ///
-    /// Client messages are amended with ID header. Server messages with optional client ID routed to clients.
+    /// Client messages are amended with ID header (u32). Server messages with optional client ID are routed to clients.
     ///
     /// When set to `json` messages are parsed as JSON. Client messages are amended with an "id" field. Server messages are routed to clients based an optional "id" field.
     /// When set to `binary` messages are parsed according to gwsocket's strict mode.

--- a/src/envvars.rs
+++ b/src/envvars.rs
@@ -1,3 +1,4 @@
+use crate::types::ConnID;
 use {std::collections::HashMap, std::net::SocketAddr, urlencoding::encode};
 
 #[derive(Clone, Debug, Default)]
@@ -38,7 +39,7 @@ impl From<CGIEnv> for HashMap<String, String> {
     }
 }
 
-pub fn replace_template_env(template: &str, conn: usize, env: &Env) -> String {
+pub fn replace_template_env(template: &str, conn: ConnID, env: &Env) -> String {
     let template = template.replace("#ID", &conn.to_string());
 
     let cgi_vars = env.cgi.clone().into();

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,7 @@ use {
 };
 
 pub type RoomID = String;
-pub type ConnID = usize;
+pub type ConnID = u32;
 pub type PortID = u16;
 
 #[derive(Debug)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,12 +3,12 @@ use {
     std::collections::HashMap,
     std::env,
     std::process::{ExitStatus, Stdio},
-    std::sync::atomic::{AtomicUsize, Ordering},
+    std::sync::atomic::{AtomicU32, Ordering},
     tokio::process::Command,
 };
 
 /// Our global unique connection id counter.
-static NEXT_CONNECTION_ID: AtomicUsize = AtomicUsize::new(1);
+static NEXT_CONNECTION_ID: AtomicU32 = AtomicU32::new(1);
 
 pub fn new_conn_id() -> ConnID {
     NEXT_CONNECTION_ID.fetch_add(1, Ordering::Relaxed)


### PR DESCRIPTION
* Change connection ID to be `u32` instead of `usize` to ensure behaviour between architectures