### PR TITLE
Feature: separate client and server framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,16 @@ OPTIONS:
     -b, --binary
             Set scalesocket to experimental binary mode
 
+        --client-frame=<MODE>
+            Enable framing and routing for client originated messages
+            
+            See --frame for options.
+
         --cmd-attach-delay <SECONDS>
             Delay before attaching to child [default: 1 for --tcp]
 
         --frame[=<MODE>...]
-            Enable framing and routing for messages
+            Enable framing and routing for all messages
             
             Client messages are amended with ID header (u32). Server messages with optional client
             ID are routed to clients.
@@ -96,7 +101,9 @@ OPTIONS:
             When set to `json` messages are parsed as JSON. Client messages are amended with an "id"
             field. Server messages are routed to clients based an optional "id" field. When set to
             `binary` messages are parsed according to gwsocket's strict mode. Unparseable messages
-            are dropped.
+            may be dropped.
+            
+            See --server-frame and --client-frame for specifying framing independently.
             
             [default: binary when set, possible values: binary, json]
 
@@ -122,6 +129,11 @@ OPTIONS:
             List of envvars to pass to child
             
             [default: PATH,DYLD_LIBRARY_PATH]
+
+        --server-frame=<MODE>
+            Enable framing and routing for server originated messages
+            
+            See --frame for options.
 
         --staticdir <DIR>
             Serve static files from directory over HTTP

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -22,7 +22,7 @@ pub struct Channel {
     pub source: Option<Source>,
     pub is_binary: bool,
     pub attach_delay: Option<u64>,
-    pub framing: Option<Framing>,
+    pub framing: Framing,
     pub tx: ToProcessTx,
     pub rx: Option<ToProcessRx>,
     pub cast_tx: FromProcessTx,
@@ -61,7 +61,7 @@ impl Channel {
             source,
             is_binary: config.binary,
             attach_delay: config.cmd_attach_delay,
-            framing: config.frame,
+            framing: config.into(),
             tx,
             rx: Some(rx),
             cast_tx,
@@ -78,7 +78,7 @@ impl Channel {
     }
 
     pub fn write_sock(&mut self, msg: Bytes) {
-        if let Ok((id, payload)) = deserialize(&msg, self.framing) {
+        if let Ok((id, payload)) = deserialize(&msg, self.framing.process_to_socket()) {
             if self.is_binary {
                 let _ = self.cast_tx.send(Message::binary(payload).to_some(id));
             } else {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::types::Framing;
+use crate::types::Frame;
 use {
     clap::{ArgAction, Parser},
     std::net::SocketAddr,
@@ -46,13 +46,15 @@ pub struct Config {
     )]
     pub passenv: Vec<String>,
 
-    /// Enable framing and routing for messages
+    /// Enable framing and routing for all messages
     ///
     /// Client messages are amended with ID header (u32). Server messages with optional client ID are routed to clients.
     ///
     /// When set to `json` messages are parsed as JSON. Client messages are amended with an "id" field. Server messages are routed to clients based an optional "id" field.
     /// When set to `binary` messages are parsed according to gwsocket's strict mode.
-    /// Unparseable messages are dropped.
+    /// Unparseable messages may be dropped.
+    ///
+    /// See --server-frame and --client-frame for specifying framing independently.
     ///
     /// [default: binary when set, possible values: binary, json]
     #[clap(
@@ -65,7 +67,33 @@ pub struct Config {
         require_equals = true,
         hide_possible_values = true
     )]
-    pub frame: Option<Framing>,
+    pub frame: Option<Frame>,
+
+    /// Enable framing and routing for client originated messages
+    ///
+    /// See --frame for options.
+    #[clap(
+        long,
+        value_parser,
+        value_name = "MODE",
+        conflicts_with = "frame",
+        require_equals = true,
+        hide_possible_values = true
+    )]
+    pub client_frame: Option<Frame>,
+
+    /// Enable framing and routing for server originated messages
+    ///
+    /// See --frame for options.
+    #[clap(
+        long,
+        value_parser,
+        value_name = "MODE",
+        conflicts_with = "frame",
+        require_equals = true,
+        hide_possible_values = true
+    )]
+    pub server_frame: Option<Frame>,
 
     /// Serve static files from directory over HTTP
     #[clap(long, value_parser, value_name = "DIR")]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -19,7 +19,7 @@ use {
 pub async fn handle(
     ws: WebSocket,
     conn: ConnID,
-    framing: Option<Framing>,
+    framing: Framing,
     proc_rx: FromProcessRx,
     proc_tx: ToProcessTx,
     barrier: Option<Arc<Barrier>>,
@@ -52,7 +52,7 @@ pub async fn handle(
             let result = sock_rx
                 .try_take_while(|msg| ready(Ok(!msg.is_close())))
                 .filter_map(|line| ready(line.ok()))
-                .map(|msg| serialize(msg, conn, framing))
+                .map(|msg| serialize(msg, conn, framing.socket_to_process()))
                 .forward(proc_tx_sink)
                 .await;
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -105,7 +105,7 @@ fn attach(
     barrier: Option<Arc<Barrier>>,
 ) {
     let conn = new_conn_id();
-    let mode = state.cfg.frame;
+    let framing = (&state.cfg).into();
 
     // Get process senders from map
     let (proc_tx_broadcast, proc_tx, _) = state.procs.get(&room).expect("room not in process map");
@@ -143,7 +143,7 @@ fn attach(
     };
 
     tokio::spawn(
-        connection::handle(*ws, conn, mode, proc_rx, proc_tx.clone(), barrier)
+        connection::handle(*ws, conn, framing, proc_rx, proc_tx.clone(), barrier)
             .then({
                 // NOTE: we invoke on_init closure immediately...
                 on_init();

--- a/src/process.rs
+++ b/src/process.rs
@@ -252,7 +252,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_process_output_framed_json() {
-        let channel = create_channel("scalesocket --frame=json echo -- {\"id\": 0}");
+        let channel = create_channel(r#"scalesocket --frame=json echo -- {"id": 0}"#);
         let mut proc_rx = channel.cast_tx.subscribe();
 
         handle(channel, None).await.ok();
@@ -276,11 +276,11 @@ mod tests {
     async fn test_handle_process_output_framed_binary() {
         let channel = create_channel(concat!(
             "scalesocket --frame printf -- ",
-            "\\002\\000\\000\\000", // id
-            "\\001\\000\\000\\000", // type
-            "\\003\\000\\000\\000", // payload length
-            "abc",                  // payload
-            "\\n"
+            r"\002\000\000\000", // id
+            r"\001\000\000\000", // type
+            r"\003\000\000\000", // payload length
+            r"abc",              // payload
+            r"\n"
         ));
         let mut proc_rx = channel.cast_tx.subscribe();
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -90,7 +90,7 @@ pub type ShutdownTx = oneshot::Sender<()>;
 pub type ShutdownRx = oneshot::Receiver<()>;
 pub type ShutdownRxStream = futures::future::IntoStream<ShutdownRx>;
 
-// Channel for passing data to from child process
+// Channel for passing data from child process
 pub type FromProcessTx = broadcast::Sender<(Option<ConnID>, Message)>;
 pub type FromProcessRx = broadcast::Receiver<(Option<ConnID>, Message)>;
 


### PR DESCRIPTION
* Add `--client-framing` and `--server-framing` arguments for specifying framing independently for client and server originated messages.