### PR TITLE
Feature: room metadata endpoint

### DIFF
--- a/docs/man/cli.md
+++ b/docs/man/cli.md
@@ -24,6 +24,14 @@ OPTIONS:
             
             [default: 0.0.0.0:9000]
 
+        --api
+            Expose room metadata API under /api/
+            
+            The exposed endpoints are:
+            * /api/rooms/          - list rooms
+            * /api/<ROOM>/         - get room metadata
+            * /api/<ROOM>/<METRIC> - get room individual metric
+
     -b, --binary
             Set scalesocket to experimental binary mode
 
@@ -80,11 +88,6 @@ OPTIONS:
 
         --staticdir <DIR>
             Serve static files from directory over HTTP
-
-        --stats
-            Expose stats endpoint at /<ROOM>/stats
-            
-            Exposed statistics can be queried individually at  /<ROOM>/stats/<STATISTIC>
 
         --tcp
             Connect to child using TCP instead of stdio. Use PORT to bind

--- a/docs/man/usage.md
+++ b/docs/man/usage.md
@@ -29,8 +29,11 @@ See the [CLI Reference](/man/cli.md) and the `--tcp`, `--tcpports` and `--cmd-at
 
 ## Rooms
 
-Clients connecting to the server specify a room in the connection URL path.
-The room ID is the first path component of the URL. For example `wss://example.com/exampleroom`.
+Clients connecting to the server specify a room in the connection URL.
+
+The room name can be specified in two ways:
+* Query parameter, eg. `wss://example.com/?room=exampleroom`
+* The first segment in the URL path, eg. `wss://example.com/exampleroom`
 
 Connecting to a room spawns a new process of the wrapped binary or script. Subsequent connections to the same room share the same process.
 

--- a/docs/man/usage.md
+++ b/docs/man/usage.md
@@ -63,6 +63,7 @@ ScaleSocket can optionally send a message to the target when a client joins or l
 
 The messages support the variables:
 * `#ID` eg. `123`
+* `QUERY_XYZ` for each query parameter, `?xyz=`, in the connection URL.
 * The [Environment variables](#environment-variables)
 
 For example, starting scalesocket with:
@@ -84,7 +85,7 @@ ScaleSocket can optionally expose CGI [environment variables](https://www.rfc-ed
 The supported environment variables are:
 * `QUERY_STRING` eg. `foo=bar&baz=qux`
 * `REMOTE_ADDR` eg. `127.0.0.1:1234`
-* `QUERY_PARAM_XYZ` for each query parameter, `?xyz=`, in the connection URL.
+* `ROOM` eg. `exampleroom`
 * `PORT` for binding in TCP mode
 * Any environment variables specified with `--passenv`
 

--- a/docs/man/usage.md
+++ b/docs/man/usage.md
@@ -99,15 +99,14 @@ ScaleSocket can expose an [OpenMetrics](https://openmetrics.io/) and [Prometheus
 
 The tracked metrics are:
 * `connections` with the label `room`
-* `unique_connections` with the label `room` (TODO)
 
 See the [CLI Reference](/man/cli.md) and the `--metrics` flag for details.
 
-### Stats Endpoint
+### Metadata Endpoint
 
-ScaleSocket can expose a JSON endpoint for retrieving stats for rooms.
+ScaleSocket can expose a JSON endpoint for retrieving rooms and their metadata.
 
-See the [CLI Reference](/man/cli.md) and the `--stats` flag for details.
+See the [CLI Reference](/man/cli.md) and the `--api` flag for details.
 
 ### Health Endpoint
 

--- a/examples/chat/Dockerfile
+++ b/examples/chat/Dockerfile
@@ -3,7 +3,6 @@ FROM scalesocket/scalesocket:latest
 COPY index.html /var/www/public/index.html
 CMD scalesocket --addr 0.0.0.0:5000\
     --staticdir /var/www/public/\
-    --frame=json\
     --stats\
     --metrics\
     cat

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,12 +99,14 @@ pub struct Config {
     #[clap(long, value_parser, value_name = "DIR")]
     pub staticdir: Option<PathBuf>,
 
-    /// Expose stats endpoint at /<ROOM>/stats
+    /// Expose room metadata API under /api/
     ///
-    /// Exposed statistics can be queried individually at  /<ROOM>/stats/<STATISTIC>
-    ///
-    #[clap(long, action)]
-    pub stats: bool,
+    /// The exposed endpoints are:
+    /// * /api/rooms/          - list rooms
+    /// * /api/<ROOM>/         - get room metadata
+    /// * /api/<ROOM>/<METRIC> - get room individual metric
+    #[clap(long, action, alias = "stats", verbatim_doc_comment)]
+    pub api: bool,
 
     /// Port range for TCP
     #[clap(long, value_parser = parse_ports, value_name = "START:END", default_value = "9001:9999")]

--- a/src/envvars.rs
+++ b/src/envvars.rs
@@ -7,24 +7,32 @@ pub struct Env {
     pub query: HashMap<String, String>,
 }
 
+impl Env {
+    pub fn set_room(&mut self, room: &str) -> &mut Self {
+        self.cgi.room = room.to_string();
+        self
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct CGIEnv {
     /// URL-encoded search or parameter string
     query_string: String,
     /// network address of the client sending the request
     remote_addr: String,
+    /// room name (non standard)
+    room: String,
 }
 
 impl CGIEnv {
     pub fn from_filter(query_string: Option<String>, remote_addr: Option<SocketAddr>) -> Self {
         let query_string = query_string.unwrap_or_default();
-        let remote_addr = remote_addr
-            .map(|a| a.to_string())
-            .unwrap_or_else(|| "".to_string());
+        let remote_addr = remote_addr.map(|a| a.to_string()).unwrap_or_default();
 
         Self {
             query_string,
             remote_addr,
+            ..Default::default()
         }
     }
 }
@@ -35,6 +43,7 @@ impl From<CGIEnv> for HashMap<String, String> {
             // NOTE: implicit uppercase
             ("QUERY_STRING".to_string(), env.query_string),
             ("REMOTE_ADDR".to_string(), env.remote_addr),
+            ("ROOM".to_string(), env.room),
         ])
     }
 }
@@ -93,6 +102,7 @@ mod tests {
         CGIEnv {
             query_string: "foo=".to_string(),
             remote_addr: "127.0.0.1:1234".to_string(),
+            room: "room".to_string(),
         }
     }
 

--- a/src/envvars.rs
+++ b/src/envvars.rs
@@ -8,20 +8,34 @@ pub struct Env {
 }
 
 impl Env {
-    pub fn set_room(&mut self, room: &str) -> &mut Self {
-        self.cgi.room = room.to_string();
-        self
+    pub fn cgi_env_with(&self, room: &str) -> CGIEnv {
+        CGIEnv {
+            room: Some(room.to_string()),
+            ..self.cgi.clone()
+        }
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
+#[cfg_attr(not(test), derive(Default))]
 pub struct CGIEnv {
     /// URL-encoded search or parameter string
     query_string: String,
     /// network address of the client sending the request
     remote_addr: String,
     /// room name (non standard)
-    room: String,
+    room: Option<String>,
+}
+
+#[cfg(test)]
+impl Default for CGIEnv {
+    fn default() -> Self {
+        Self {
+            query_string: String::default(),
+            remote_addr: String::default(),
+            room: Some("".to_string()),
+        }
+    }
 }
 
 impl CGIEnv {
@@ -43,7 +57,7 @@ impl From<CGIEnv> for HashMap<String, String> {
             // NOTE: implicit uppercase
             ("QUERY_STRING".to_string(), env.query_string),
             ("REMOTE_ADDR".to_string(), env.remote_addr),
-            ("ROOM".to_string(), env.room),
+            ("ROOM".to_string(), env.room.expect("room to be defined")),
         ])
     }
 }
@@ -102,7 +116,7 @@ mod tests {
         CGIEnv {
             query_string: "foo=".to_string(),
             remote_addr: "127.0.0.1:1234".to_string(),
-            room: "room".to_string(),
+            room: "room".to_string().into(),
         }
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -156,7 +156,7 @@ fn attach(
 
 #[instrument(name = "spawn", skip(env, tx, state, barrier))]
 fn spawn(
-    room: &RoomID,
+    room: &str,
     env: &Env,
     tx: &EventTx,
     state: &mut State,
@@ -168,7 +168,7 @@ fn spawn(
         tracing::debug!("reserved port {}", port);
     }
 
-    let mut proc = Channel::new(&state.cfg, port, env.cgi.clone());
+    let mut proc = Channel::new(&state.cfg, port, env.cgi_env_with(room));
     let senders = proc.take_senders();
 
     let on_init = || {

--- a/src/events.rs
+++ b/src/events.rs
@@ -66,6 +66,7 @@ pub async fn handle(
                 }
             }
             Event::ProcessExit { room, code, port } => {
+                metrics.clear(&room);
                 exit(room, code, port, &mut state);
 
                 if is_oneshot {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ async fn main() {
     let events_shutdown_tx = tx.clone();
 
     let mut registry = config.metrics.then_some(<Registry>::default());
-    let mtr = Metrics::new(&mut registry);
+    let mtr = Metrics::new(&mut registry, config.stats);
 
     tracing::info! { "listening at {}", config.addr };
 
@@ -94,7 +94,7 @@ mod tests {
     }
 
     fn create_metrics() -> Metrics {
-        Metrics::new(&mut Some(<Registry>::default()))
+        Metrics::new(&mut Some(<Registry>::default()), true)
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ async fn main() {
     let events_shutdown_tx = tx.clone();
 
     let mut registry = config.metrics.then_some(<Registry>::default());
-    let mtr = Metrics::new(&mut registry, config.stats);
+    let mtr = Metrics::new(&mut registry, config.api);
 
     tracing::info! { "listening at {}", config.addr };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,17 +98,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn socket_connect_event() {
+    async fn connects_to_room_from_path() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
-        Client::connect("/example", tx).await.send("hello").await;
+        Client::connect("/example", tx).await;
 
         let received_event = rx.recv().await.unwrap();
         let room = match received_event {
-            Event::Connect { room, .. } => Some(room),
+            Event::Connect { ref room, .. } => Some(room.as_str()),
             _ => None,
         };
 
-        assert_eq!(Some("example".to_string()), room);
+        assert_eq!(Some("example"), room);
+    }
+
+    #[tokio::test]
+    async fn connects_to_room_from_query() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
+        Client::connect("/example?room=other", tx).await;
+
+        let received_event = rx.recv().await.unwrap();
+        let room = match received_event {
+            Event::Connect { ref room, .. } => Some(room.as_str()),
+            _ => None,
+        };
+
+        assert_eq!(Some("other"), room);
     }
 
     #[tokio::test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -30,13 +30,13 @@ impl Metrics {
 
         if let Some(registry) = registry {
             registry.register(
-                "scalesocket_websocket_connections_total",
+                "scalesocket_websocket_connections",
                 "Number of total websocket connections",
                 ws_connections_counter.clone(),
             );
             registry.register(
                 "scalesocket_websocket_connections_open",
-                "number of open websocket connections",
+                "Number of open websocket connections",
                 ws_connections_open_gauge.clone(),
             );
         }

--- a/src/process.rs
+++ b/src/process.rs
@@ -215,7 +215,6 @@ mod tests {
         handle(channel, None).await.ok();
         let output = BroadcastStream::new(proc_rx)
             .filter_map(|d| async { d.ok() })
-            .take(2)
             .collect::<Vec<_>>()
             .await;
 
@@ -224,6 +223,7 @@ mod tests {
             vec![
                 Message::text("QUERY_STRING=").broadcast(),
                 Message::text("REMOTE_ADDR=").broadcast(),
+                Message::text("ROOM=").broadcast(),
             ]
         );
     }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -51,7 +51,7 @@ pub fn socket(tx: EventTx) -> impl Filter<Extract = (impl Reply,), Error = Rejec
         .and(warp::path::end())
         .and(warp::ws())
         .and(warpext::env())
-        .map(move |room: RoomID, websocket: Ws, mut env: Env| {
+        .map(move |room: RoomID, websocket: Ws, env: Env| {
             let tx = tx.clone();
             websocket.on_upgrade(move |ws| {
                 let event = Event::Connect {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -30,8 +30,8 @@ pub fn handle(
         socket(tx)
             .or(health())
             .or(openmetrics(registry, config.metrics))
-            .or(rooms_api(metrics.clone(), config.stats))
-            .or(metadata_api(metrics, config.stats))
+            .or(rooms_api(metrics.clone(), config.api))
+            .or(metadata_api(metrics, config.api))
             .or(files(config.staticdir.clone())),
     )
     .bind_with_graceful_shutdown(config.addr, shutdown_rx)
@@ -239,7 +239,11 @@ mod tests {
 
         let api = metadata_api(metrics, true);
 
-        let resp = request().method("GET").path("/foo/stats/").reply(&api).await;
+        let resp = request()
+            .method("GET")
+            .path("/foo/stats/")
+            .reply(&api)
+            .await;
 
         assert!(resp.status().is_success());
         let body: Value = serde_json::from_slice(resp.body()).unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,14 +12,14 @@ pub type PortID = u16;
 #[derive(Debug)]
 pub enum Event {
     Connect {
+        env: Env,
         room: RoomID,
         ws: Box<WebSocket>,
-        env: Env,
     },
     Disconnect {
+        env: Env,
         room: RoomID,
         conn: ConnID,
-        env: Env,
     },
     ProcessExit {
         room: RoomID,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -89,4 +89,20 @@ pub mod warpext {
             // deal with Ok(())
             .untuple_one()
     }
+
+    pub mod path_or_query {
+        use super::*;
+
+        pub fn param(
+            name: &'static str,
+        ) -> impl Filter<Extract = One<String>, Error = Rejection> + Copy {
+            warp::path::param::<String>()
+                .and(warp::query::query())
+                .and_then(async move |path, query: HashMap<String, String>| {
+                    Ok::<_, Rejection>((query.get(name).unwrap_or(&path).to_owned(),))
+                })
+                // deal with Ok(())
+                .untuple_one()
+        }
+    }
 }


### PR DESCRIPTION
* Mark `/<ROOM>/stats` endpoint and `--stats` flag deprecated.
* Move `/<ROOM>/stats` endpoint to `/api/<ROOM>` and rename `--stats` flag to `--api`.
* Add `/api/rooms` endpoint for listing rooms.
* Add option for specifying room in connection URL query parameter using `?room=`.
* Add CGI environment variable `ROOM`.
* Fix `scalesocket_websocket_connections_total` metric name.