### PR TITLE
 Fix: rename json frame headers to _from and _to

### DIFF
--- a/docs/man/cli.md
+++ b/docs/man/cli.md
@@ -49,10 +49,10 @@ OPTIONS:
             Client messages are tagged with an ID header (u32). Server messages with optional client
             ID are routed to clients.
             
-            When set to `json` messages are parsed as JSON. Client messages are amended with an "id"
-            field. Server messages are routed to clients based an optional "id" field. When set to
-            `binary` messages are parsed according to gwsocket's strict mode. Unparseable messages
-            may be dropped.
+            When set to `json` messages are parsed as JSON. Client messages are amended with an
+            "_from" field. Server messages are routed to clients based an optional "_to" field. When
+            set to `binary` messages are parsed according to gwsocket's strict mode. Unparseable
+            messages may be dropped.
             
             See --server-frame and --client-frame for specifying framing independently.
             

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,7 +50,7 @@ pub struct Config {
     ///
     /// Client messages are tagged with an ID header (u32). Server messages with optional client ID are routed to clients.
     ///
-    /// When set to `json` messages are parsed as JSON. Client messages are amended with an "id" field. Server messages are routed to clients based an optional "id" field.
+    /// When set to `json` messages are parsed as JSON. Client messages are amended with an "_from" field. Server messages are routed to clients based an optional "_to" field.
     /// When set to `binary` messages are parsed according to gwsocket's strict mode.
     /// Unparseable messages may be dropped.
     ///

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,9 +1,9 @@
-use serde_json::Value;
-
 use crate::types::{ConnID, Frame};
-use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
-use {bytes::Bytes, sender_sink::wrappers::SinkError, warp::ws::Message};
+
+use {
+    bytes::Bytes, num_derive::FromPrimitive, num_traits::FromPrimitive,
+    sender_sink::wrappers::SinkError, serde_json::Value, warp::ws::Message,
+};
 
 /// An extension trait for `Message`s that provides routing helpers
 pub trait Address<T> {
@@ -26,6 +26,7 @@ impl Address<Message> for Message {
     }
 }
 
+/// Deserialize message going to client
 pub fn deserialize(
     msg: &Bytes,
     frame: Option<Frame>,
@@ -58,13 +59,14 @@ pub fn deserialize(
     }
 }
 
+/// Serialize message going to process
 pub fn serialize(msg: Message, conn: ConnID, frame: Option<Frame>) -> Result<Message, SinkError> {
     match frame {
         Some(f) => match f {
             Frame::Binary => unimplemented!("Client side binary framing has not been implemented"),
             Frame::JSON => match serde_json::from_slice::<Value>(msg.as_bytes()) {
                 Ok(mut v) if v.is_object() => {
-                    v["id"] = Value::from(conn);
+                    v["_from"] = Value::from(conn);
                     Ok(Message::text(v.to_string()))
                 }
                 Ok(_) => {
@@ -90,7 +92,7 @@ pub enum Type {
 pub fn parse_json_header(msg: &Bytes) -> (Option<ConnID>, &[u8]) {
     let id = match serde_json::from_slice::<Value>(msg) {
         Ok(ref payload) => payload
-            .get("id")
+            .get("_to")
             .and_then(|v: &Value| v.as_u64())
             .and_then(|v: u64| u32::try_from(v).ok()),
         _ => None,

--- a/src/process.rs
+++ b/src/process.rs
@@ -252,24 +252,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_process_output_framed_json() {
-        let channel = create_channel(r#"scalesocket --frame=json echo -- {"id": 0}"#);
+        let channel = create_channel(r#"scalesocket --frame=json echo -- {"_to": 0}"#);
         let mut proc_rx = channel.cast_tx.subscribe();
 
         handle(channel, None).await.ok();
         let output = proc_rx.recv().await.ok();
 
-        assert_eq!(output, Some(Message::text("{\"id\": 0}").to(0)));
+        assert_eq!(output, Some(Message::text(r#"{"_to": 0}"#).to(0)));
     }
 
     #[tokio::test]
     async fn test_handle_process_output_server_framed_json() {
-        let channel = create_channel(r#"scalesocket --server-frame=json echo -- {"id": 0}"#);
+        let channel = create_channel(r#"scalesocket --server-frame=json echo -- {"_to": 0}"#);
         let mut proc_rx = channel.cast_tx.subscribe();
 
         handle(channel, None).await.ok();
         let output = proc_rx.recv().await.ok();
 
-        assert_eq!(output, Some(Message::text("{\"id\": 0}").to(0)));
+        assert_eq!(output, Some(Message::text(r#"{"_to": 0}"#).to(0)));
     }
 
     #[tokio::test]
@@ -338,9 +338,7 @@ mod tests {
         let sock_tx = channel.tx.clone();
 
         let send = async {
-            sock_tx
-                .send(Message::text("{'id': 1, 'msg': 'foo'}\n"))
-                .ok();
+            sock_tx.send(Message::text("{'msg': 'foo'}\n")).ok();
             Ok(())
         };
         let handle = handle(channel, None);
@@ -348,9 +346,6 @@ mod tests {
         tokio::try_join!(handle, send).ok();
         let output = proc_rx.recv().await.ok();
 
-        assert_eq!(
-            output,
-            Some(Message::text("{'id': 1, 'msg': 'foo'}").broadcast())
-        );
+        assert_eq!(output, Some(Message::text("{'msg': 'foo'}").broadcast()));
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,7 +10,11 @@ use {
 /// Our global unique connection id counter.
 static NEXT_CONNECTION_ID: AtomicU32 = AtomicU32::new(1);
 
+#[allow(unreachable_code)]
 pub fn new_conn_id() -> ConnID {
+    #[cfg(test)]
+    return 1;
+
     NEXT_CONNECTION_ID.fetch_add(1, Ordering::Relaxed)
 }
 


### PR DESCRIPTION
* Rename client side `id` field to `_from` and server side `id` field to `_to` in order to distinguish headers.