### PR TITLE
Fix: validate room parameter

### DIFF
--- a/docs/man/usage.md
+++ b/docs/man/usage.md
@@ -29,11 +29,8 @@ See the [CLI Reference](/man/cli.md) and the `--tcp`, `--tcpports` and `--cmd-at
 
 ## Rooms
 
-Clients connecting to the server specify a room in the connection URL.
-
-The room name can be specified in two ways:
-* Query parameter, eg. `wss://example.com/?room=exampleroom`
-* The first segment in the URL path, eg. `wss://example.com/exampleroom`
+Clients connecting to the server specify a room in the connection URL path.
+The room ID is the first path component of the URL. For example `wss://example.com/exampleroom`.
 
 Connecting to a room spawns a new process of the wrapped binary or script. Subsequent connections to the same room share the same process.
 

--- a/src/envvars.rs
+++ b/src/envvars.rs
@@ -8,11 +8,8 @@ pub struct Env {
 }
 
 impl Env {
-    pub fn cgi_env_with(&self, room: &str) -> CGIEnv {
-        CGIEnv {
-            room: Some(room.to_string()),
-            ..self.cgi.clone()
-        }
+    pub fn set_room(&mut self, room: &str) {
+        self.cgi.room = Some(room.to_string());
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -169,7 +169,7 @@ fn spawn(
         tracing::debug!("reserved port {}", port);
     }
 
-    let mut proc = Channel::new(&state.cfg, port, env.cgi_env_with(room));
+    let mut proc = Channel::new(&state.cfg, port, env.cgi.clone());
     let senders = proc.take_senders();
 
     let on_init = || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,31 +105,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn connects_to_room_from_path() {
+    async fn connects_to_room() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
         Client::connect("/example", tx).await;
 
         let received_event = rx.recv().await.unwrap();
         let room = match received_event {
-            Event::Connect { ref room, .. } => Some(room.as_str()),
+            Event::Connect { room, .. } => Some(room),
             _ => None,
         };
 
-        assert_eq!(Some("example"), room);
-    }
-
-    #[tokio::test]
-    async fn connects_to_room_from_query() {
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
-        Client::connect("/example?room=other", tx).await;
-
-        let received_event = rx.recv().await.unwrap();
-        let room = match received_event {
-            Event::Connect { ref room, .. } => Some(room.as_str()),
-            _ => None,
-        };
-
-        assert_eq!(Some("other"), room);
+        assert_eq!(Some("example".to_string()), room);
     }
 
     #[tokio::test]

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -44,8 +44,9 @@ pub fn socket(tx: EventTx) -> impl Filter<Extract = (impl Reply,), Error = Rejec
         .and(warp::path::end())
         .and(warp::ws())
         .and(warpext::env())
-        .map(move |room: RoomID, websocket: Ws, env: Env| {
+        .map(move |room: RoomID, websocket: Ws, mut env: Env| {
             let tx = tx.clone();
+            env.set_room(&room);
             websocket.on_upgrade(move |ws| {
                 let ws = Box::new(ws);
                 let event = Event::Connect { env, room, ws };

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -3,7 +3,7 @@ use crate::{
     envvars::Env,
     metrics::Metrics,
     types::{Event, EventTx, RoomID, ShutdownRx},
-    utils::warpext,
+    utils::warpext::{self, handle_rejection},
 };
 
 use {
@@ -14,6 +14,8 @@ use {
     warp::ws::Ws,
     warp::{self, http::Response, Filter, Rejection, Reply},
 };
+
+const RESERVED_ROOMS: &[&str] = &["api", "metrics", "health", "static"];
 
 pub fn handle(
     tx: EventTx,
@@ -32,14 +34,15 @@ pub fn handle(
             .or(openmetrics(registry, config.metrics))
             .or(rooms_api(metrics.clone(), config.api))
             .or(metadata_api(metrics, config.api))
-            .or(files(config.staticdir.clone())),
+            .or(files(config.staticdir.clone()))
+            .recover(handle_rejection),
     )
     .bind_with_graceful_shutdown(config.addr, shutdown_rx)
     .1
 }
 
 pub fn socket(tx: EventTx) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
-    warp::path!(String)
+    warpext::path::param_not::<RoomID>(RESERVED_ROOMS)
         .and(warp::path::end())
         .and(warp::ws())
         .and(warpext::env())
@@ -159,6 +162,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn socket_rejects_invalid_room() {
+        let (tx, _) = tokio::sync::mpsc::unbounded_channel::<Event>();
+        let api = socket(tx).recover(handle_rejection);
+
+        let ws = |path: &'static str| {
+            request()
+                .method("GET")
+                .header("Connection", "Upgrade")
+                .header("Upgrade", "websocket")
+                .header("Sec-WebSocket-Key", "SGVsbG8sIHdvcmxkIQ==")
+                .header("Sec-WebSocket-Version", 13)
+                .path(path)
+                .reply(&api)
+        };
+
+        assert_eq!(ws("/ok").await.status(), StatusCode::SWITCHING_PROTOCOLS);
+        assert_eq!(ws("/api").await.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(ws("/api/rooms").await.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(ws("/metrics").await.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(ws("/health").await.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
     async fn metrics_returns_metrics() {
         let mut registry = <Registry>::default();
         registry.register(
@@ -170,7 +196,7 @@ mod tests {
 
         let resp = request().method("GET").path("/metrics").reply(&api).await;
 
-        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(resp.status().is_success());
         assert_eq!(
             resp.body(),
             "# HELP example_metric Example description.\n# TYPE example_metric counter\n# EOF\n"

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -39,8 +39,7 @@ pub fn handle(
 }
 
 pub fn socket(tx: EventTx) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
-    warp::any()
-        .and(warpext::path_or_query::param("room"))
+    warp::path!(String)
         .and(warp::path::end())
         .and(warp::ws())
         .and(warpext::env())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -93,20 +93,4 @@ pub mod warpext {
             // deal with Ok(())
             .untuple_one()
     }
-
-    pub mod path_or_query {
-        use super::*;
-
-        pub fn param(
-            name: &'static str,
-        ) -> impl Filter<Extract = One<String>, Error = Rejection> + Copy {
-            warp::path::param::<String>()
-                .and(warp::query::query())
-                .and_then(async move |path, query: HashMap<String, String>| {
-                    Ok::<_, Rejection>((query.get(name).unwrap_or(&path).to_owned(),))
-                })
-                // deal with Ok(())
-                .untuple_one()
-        }
-    }
 }


### PR DESCRIPTION
* Remove option for specifying room in connection URL query parameter using `?room=`.
* Fix CGI environment variable `ROOM`.
* Disallow reserved room names in order to avoid conflicts with HTTP endpoints.