### PR TITLE
Fix: revise CLI arguments

### DIFF
--- a/docs/man/cli.md
+++ b/docs/man/cli.md
@@ -29,6 +29,9 @@ Options:
       --json
           Log JSON
 
+      --delay <SECONDS>
+          Delay before attaching to child [default: 1 for --tcp]
+
       --joinmsg <MSG>
           Emit message to child on client connect (use #ID for id)
 
@@ -57,16 +60,16 @@ Options:
           
           When set to `binary`, messages are parsed according to gwsocket's strict mode. Unparseable messages may be dropped.
           
-          See --server-frame and --client-frame for specifying framing independently.
+          See --serverframe and --clientframe for specifying framing independently.
           
           [default: binary when set, possible values: binary, json]
 
-      --client-frame=<MODE>
+      --clientframe=<MODE>
           Enable framing and routing for client originated messages
           
           See --frame for options.
 
-      --server-frame=<MODE>
+      --serverframe=<MODE>
           Enable framing and routing for server originated messages
           
           See --frame for options.
@@ -82,19 +85,16 @@ Options:
           * /api/<ROOM>/         - get room metadata
           * /api/<ROOM>/<METRIC> - get room individual metric
 
+      --tcp
+          Connect to child using TCP instead of stdio. Use PORT to bind
+
       --tcpports <START:END>
           Port range for TCP
           
           [default: 9001:9999]
 
-      --tcp
-          Connect to child using TCP instead of stdio. Use PORT to bind
-
   -v...
           Increase level of verbosity
-
-      --cmd-attach-delay <SECONDS>
-          Delay before attaching to child [default: 1 for --tcp]
 
   -h, --help
           Print help (see a summary with '-h')

--- a/docs/man/cli.md
+++ b/docs/man/cli.md
@@ -32,6 +32,11 @@ Options:
       --joinmsg <MSG>
           Emit message to child on client connect (use #ID for id)
 
+      --json
+          Enable JSON framing with default join and leave messages
+          
+          This option is equivalent to --frame=json --joinmsg '{"t":"Join","_from":#ID}' --leavemsg '{"t":"Leave","_from":#ID}'
+
       --leavemsg <MSG>
           Emit message to child on client disconnect (use #ID for id)
 

--- a/docs/man/cli.md
+++ b/docs/man/cli.md
@@ -26,9 +26,6 @@ Options:
   -b, --binary
           Set scalesocket to experimental binary mode
 
-      --json
-          Log JSON
-
       --delay <SECONDS>
           Delay before attaching to child [default: 1 for --tcp]
 
@@ -37,6 +34,11 @@ Options:
 
       --leavemsg <MSG>
           Emit message to child on client disconnect (use #ID for id)
+
+      --log <FMT>
+          Log format
+          
+          [default: text, possible values: text, json]
 
       --metrics
           Expose OpenMetrics endpoint at /metrics

--- a/docs/man/usage.md
+++ b/docs/man/usage.md
@@ -25,7 +25,7 @@ Alternatively, the messages can be sent to the target over a TCP socket.
 
 When using TCP mode, the target must be configured to bind to the port specified by the environment variable `PORT`.
 
-See the [CLI Reference](/man/cli.md) and the `--tcp`, `--tcpports` and `--cmd-attach-delay` arguments for details.
+See the [CLI Reference](/man/cli.md) and the `--tcp`, `--tcpports` and `--delay` arguments for details.
 
 ## Rooms
 
@@ -55,7 +55,7 @@ When `--frame=binary` is enabled, ScaleSocket is compatible with [gwsocket](http
 * Messages from the client must set the header type to `0x01` (text)
 * Messages from the server, that contain a nonzero client `id` field will be routed to the specific client
 
-See the [CLI Reference](/man/cli.md) and the `--frame`, `--server-frame` and `--client-frame` arguments for details.
+See the [CLI Reference](/man/cli.md) and the `--frame`, `--serverframe` and `--clientframe` arguments for details.
 
 ## Join and Leave Messages
 

--- a/examples/multiplayer/Dockerfile
+++ b/examples/multiplayer/Dockerfile
@@ -9,9 +9,7 @@ COPY server.py .
 
 CMD scalesocket --addr 0.0.0.0:5000\
     --staticdir /var/www/public/\
-    --frame=json\
-    --joinmsg '{"t":"Join","_from":#ID}'\
-    --leavemsg '{"t":"Leave","_from":#ID}'\
+    --json\
     --api\
     --metrics\
     /app/server.py

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -65,7 +65,7 @@ impl Channel {
             source,
             is_binary: config.binary,
             room: room.to_string(),
-            attach_delay: config.cmd_attach_delay,
+            attach_delay: config.delay,
             framing: config.into(),
             tx,
             rx: Some(rx),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ use {
     std::path::PathBuf,
 };
 
-use crate::types::Frame;
+use crate::types::{Frame, Log};
 
 #[derive(Parser, Debug, Clone)]
 #[clap(author, version, about, long_about = None)]
@@ -19,10 +19,6 @@ pub struct Config {
     #[clap(short, long, action)]
     pub binary: bool,
 
-    /// Log JSON
-    #[clap(long, action)]
-    pub json: bool,
-
     /// Delay before attaching to child [default: 1 for --tcp]
     #[clap(
         long = "delay",
@@ -32,12 +28,34 @@ pub struct Config {
     pub delay: Option<u64>,
 
     /// Emit message to child on client connect (use #ID for id)
-    #[clap(long, value_name = "MSG")]
+    #[clap(
+        long,
+        value_name = "MSG",
+        default_value_if("json",  ArgPredicate::Equals("true".into()), Some(r#"{"t":"Join","_from":#ID}"#))
+    )]
     pub joinmsg: Option<String>,
 
     /// Emit message to child on client disconnect (use #ID for id)
-    #[clap(long, value_name = "MSG")]
+    #[clap(
+        long,
+        value_name = "MSG",
+        default_value_if("json",  ArgPredicate::Equals("true".into()), Some(r#"{"t":"Leave","_from":#ID}"#))
+    )]
     pub leavemsg: Option<String>,
+
+    /// Log format
+    ///
+    /// [default: text, possible values: text, json]
+    #[clap(
+        long,
+        action,
+        value_parser,
+        value_name = "FMT",
+        default_value = "text",
+        hide_possible_values = true,
+        hide_default_value = true
+    )]
+    pub log: Log,
 
     /// Expose OpenMetrics endpoint at /metrics
     #[clap(long, action)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,14 @@ pub struct Config {
     #[clap(long, action)]
     pub json: bool,
 
+    /// Delay before attaching to child [default: 1 for --tcp]
+    #[clap(
+        long = "delay",
+        value_name = "SECONDS",
+        default_value_if("tcp",  ArgPredicate::Equals("true".into()), Some("1"))
+    )]
+    pub delay: Option<u64>,
+
     /// Emit message to child on client connect (use #ID for id)
     #[clap(long, value_name = "MSG")]
     pub joinmsg: Option<String>,
@@ -61,7 +69,7 @@ pub struct Config {
     /// When set to `binary`, messages are parsed according to gwsocket's strict mode.
     /// Unparseable messages may be dropped.
     ///
-    /// See --server-frame and --client-frame for specifying framing independently.
+    /// See --serverframe and --clientframe for specifying framing independently.
     ///
     /// [default: binary when set, possible values: binary, json]
     #[clap(
@@ -80,7 +88,7 @@ pub struct Config {
     ///
     /// See --frame for options.
     #[clap(
-        long,
+        long = "clientframe",
         value_parser,
         value_name = "MODE",
         conflicts_with = "frame",
@@ -93,7 +101,7 @@ pub struct Config {
     ///
     /// See --frame for options.
     #[clap(
-        long,
+        long = "serverframe",
         value_parser,
         value_name = "MODE",
         conflicts_with = "frame",
@@ -115,25 +123,17 @@ pub struct Config {
     #[clap(long, action, alias = "stats", verbatim_doc_comment)]
     pub api: bool,
 
-    /// Port range for TCP
-    #[clap(long, value_parser = parse_ports, value_name = "START:END", default_value = "9001:9999")]
-    pub tcpports: Range<u16>,
-
     /// Connect to child using TCP instead of stdio. Use PORT to bind
     #[clap(long, action)]
     pub tcp: bool,
 
+    /// Port range for TCP
+    #[clap(long, value_parser = parse_ports, value_name = "START:END", default_value = "9001:9999")]
+    pub tcpports: Range<u16>,
+
     /// Increase level of verbosity
     #[clap(short, action = ArgAction::Count)]
     pub verbosity: u8,
-
-    /// Delay before attaching to child [default: 1 for --tcp]
-    #[clap(
-        long,
-        value_name = "SECONDS",
-        default_value_if("tcp",  ArgPredicate::Equals("true".into()), Some("1"))
-    )]
-    pub cmd_attach_delay: Option<u64>,
 
     /// Command to wrap
     #[clap(required = true)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,19 @@ pub struct Config {
     )]
     pub joinmsg: Option<String>,
 
+    /// Enable JSON framing with default join and leave messages
+    ///
+    /// This option is equivalent to
+    /// --frame=json --joinmsg '{"t":"Join","_from":#ID}' --leavemsg '{"t":"Leave","_from":#ID}'
+    #[clap(
+        long,
+        action,
+        conflicts_with = "client_frame",
+        conflicts_with = "server_frame",
+        conflicts_with = "frame"
+    )]
+    pub json: bool,
+
     /// Emit message to child on client disconnect (use #ID for id)
     #[clap(
         long,
@@ -96,6 +109,7 @@ pub struct Config {
         value_parser,
         value_name = "MODE",
         default_missing_value = "binary",
+        default_value_if("json",  ArgPredicate::Equals("true".into()), Some("json")),
         num_args = 0..,
         require_equals = true,
         hide_possible_values = true

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,6 +1,6 @@
 use tracing_subscriber::{filter::LevelFilter, fmt::layer, prelude::*, Registry};
 
-use crate::cli::Config;
+use crate::{cli::Config, types::Log};
 
 pub fn setup_logging(config: &Config) {
     let level = match config.verbosity {
@@ -11,7 +11,7 @@ pub fn setup_logging(config: &Config) {
     let subscriber = Registry::default();
 
     // Tracing can only disable layers during runtime using Option<Layer>
-    let (json_log, plain_log) = if config.json {
+    let (json_log, plain_log) = if let Log::JSON = config.log {
         let layer = layer()
             .compact()
             .without_time()

--- a/src/process.rs
+++ b/src/process.rs
@@ -273,7 +273,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_process_output_server_framed_json() {
-        let channel = create_channel(r#"scalesocket --server-frame=json echo -- {"_to": 0}"#);
+        let channel = create_channel(r#"scalesocket --serverframe=json echo -- {"_to": 0}"#);
         let mut proc_rx = channel.cast_tx.subscribe();
 
         handle(channel, None).await.ok();
@@ -305,7 +305,7 @@ mod tests {
     async fn test_handle_process_output_metadata_json() {
         let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
         let channel = create_channel_with_event_tx(
-            r#"scalesocket --server-frame=json echo -- {"_meta": true, "foo": "bar"}"#,
+            r#"scalesocket --serverframe=json echo -- {"_meta": true, "foo": "bar"}"#,
             event_tx,
         );
 
@@ -359,7 +359,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_process_input_client_framed_json() {
-        let channel = create_channel("scalesocket --client-frame=json head -- -n 1");
+        let channel = create_channel("scalesocket --clientframe=json head -- -n 1");
         let mut proc_rx = channel.cast_tx.subscribe();
         let sock_tx = channel.tx.clone();
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -108,6 +108,13 @@ pub enum Frame {
     Binary,
 }
 
+#[derive(Debug, clap::ValueEnum, Clone, Copy)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum Log {
+    JSON,
+    Text,
+}
+
 // Channel for app events
 pub type EventTx = mpsc::UnboundedSender<Event>;
 pub type EventRx = mpsc::UnboundedReceiver<Event>;


### PR DESCRIPTION
* Rename and update `--json` to `--log=json` for setting log format
* Add `--json` for enabling of common JSON features
* Rename `--server-framing` to `--serverframing`
* Rename `--client-framing` to `--clientframing`
* Rename `--cmd-attach-delay` to `--delay`
* Rename `--server-framing` to `--serverframing`
* Rename `--server-framing` to `--serverframing`