### PR TITLE
Feature: message cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +547,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1135,6 +1154,7 @@ dependencies = [
  "bytes",
  "clap",
  "futures",
+ "heapless",
  "id-pool",
  "mark-flaky-tests",
  "num-derive",
@@ -1340,6 +1360,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = [".github/", ".tool-versions", "Dockerfile", "docs/", "examples/", "ru
 bytes = "1.4.0"
 clap = { version = "4.3.21", features = ["derive"] }
 futures = "0.3.28"
+heapless = "0.8.0"
 id-pool = { version = "0.2.2", default-features = false, features = ["u16"] }
 num-traits = "0.2"
 num-derive = "0.4"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
----
-title: Introduction
----
-
 # ScaleSocket
 
 [![Build status](https://github.com/scalesocket/scalesocket/actions/workflows/ci.yml/badge.svg)](https://github.com/scalesocket/scalesocket/actions)
@@ -67,54 +63,6 @@ $ curl --include \
 ```
 
 For more advanced usage and features, see [usage](https://www.scalesocket.org/man/usage.md).
-
-## Architecture
-
-The implementation relies heavily on async tasks and channels.
-The main async tasks and channels (Tx/Rx) are outlined in the diagram below.
-
-```
-┌────────────────────────────────────────┐
-│   ╔════╗     ╔════╗                    │▒
-│   ║ WS ║     ║ WS ║       Internet     │▒
-│   ╚═╦══╝     ╚═╦══╝                    │▒
-╞═╤═══╩══════════╩═════╤═════════════════╡▒
-│ │  routes::handle()  │◀╌╌╌╌╌╌╌┐        │▒
-│ └────────────────────┘        ╎        │▒
-│           │                   ╎        │▒
-│        EventTx            Websocket    │▒
-│           │                   ╎        │▒
-│           ▼                   ╎        │▒
-│ ┌────────────────────┐        ╎        │▒
-│ │  events::handle()  │        ╎        │▒
-│ ├─────────┬──────────┤        ╎        │▒
-│ │ spawn() │ attach() │        ╎        │▒
-│ └────┬────┴────┬─────┘        ╎        │▒
-│      │         │              ╎        │▒
-│      │         │              ▼        │▒
-│      │    ┌────┴─────────────────┐     │▒
-│      │    │ connection::handle() │     │▒
-│      │    └──────────────────────┘     │▒
-│      │         ▲                       │▒
-│      │         │                       │▒
-│      │   FromProcessRx                 │▒
-│      │    ToProcessTx                  │▒
-│      │         │                       │▒
-│      │         ▼                       │▒
-│ ┌────┴──────────────┐                  │▒
-│ │                   │ ◀╌╌╌╌╌╌─┐        │▒
-│ │ process::handle() │         ╎        │▒
-│ │                   │ FromProcessRxAny │▒
-│ ├───────────────────┤  ToProcessTxAny  │▒
-│ │                   │         ╎        │▒
-│ │      spawn()      │         ▼        │▒
-╞═╧═════════╦═════════╧══════════════════╡▒
-│      ╔════╩════╗                       │▒
-│      ║ Process ║             OS        │▒
-│      ╚═════════╝                       │▒
-└────────────────────────────────────────┘▒
- ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
-```
 
 ## License
 

--- a/docs/_assets/style.css
+++ b/docs/_assets/style.css
@@ -9,11 +9,3 @@ img[src*="scalesocket.svg"] {
     margin: 0 !important;
     display: none;
 }
-
-.header-tabs > div:first-child {
-    display: none;
-}
-
-.header-tabs > div:nth-child(2) {
-    margin-left: 0 !important;
-}

--- a/docs/man/advanced_usage.md
+++ b/docs/man/advanced_usage.md
@@ -1,0 +1,62 @@
+# Advanced Usage
+
+## Environment Variables
+
+ScaleSocket can optionally expose CGI [environment variables](https://www.rfc-editor.org/rfc/rfc3875.html) to the target.
+
+
+The supported environment variables are:
+* `QUERY_STRING` eg. `foo=bar&baz=qux`
+* `REMOTE_ADDR` eg. `127.0.0.1:1234`
+* `ROOM` eg. `exampleroom`
+* `PORT` for binding in TCP mode
+* Any environment variables specified with `--passenv`
+
+See the [CLI Reference](/man/cli.md) and the `--passenv` argument for details.
+
+## HTTP Endpoints
+
+### Metrics Endpoint
+
+ScaleSocket can expose an [OpenMetrics](https://openmetrics.io/) and [Prometheus](https://prometheus.io/) compatible endpoint for scraping metrics.
+
+The tracked metrics are:
+* `scalesocket_websocket_connections` with the label `room`
+* `scalesocket_websocket_connections_total` with the label `room`
+
+See the [CLI Reference](/man/cli.md) and the `--metrics` flag for details.
+
+### Metadata Endpoint
+
+ScaleSocket can expose a JSON endpoint for retrieving rooms and their metadata.
+
+When `--framing` is set to JSON, additional metadata can be set by the server using messages with a `_meta: true` field.
+This is useful for building a lobby or room list.
+
+See the [CLI Reference](/man/cli.md) and the `--api` flag for details.
+
+### Health Endpoint
+
+ScaleSocket exposes a standard `/health` endpoint for checking readiness.
+
+## Caching
+
+ScaleSocket can optionally cache server sent messages, and send them to new clients when they join a room.
+
+Two types of caching are supported: `all` and `tagged`. Supported cache sizes are `1`, `8` and `64`.
+
+This is an experimental feature.
+
+### Caching All Messages
+
+When `--cache=all:8` is enabled, the last 8 messages sent by the server will be cached.
+
+This is useful for enabling a chat history.
+
+### Caching Tagged Messages
+
+When `--framing` is set to JSON, and `--cache=tagged:8` is enabled, only messages with a `_cache: true` field will be cached.
+
+This is useful for maintaining a state that is sent quickly to clients when they join a room.
+
+See the [CLI Reference](/man/cli.md) and the `--cache` and `--cachepersist` arguments for details.

--- a/docs/man/cli.md
+++ b/docs/man/cli.md
@@ -34,6 +34,9 @@ Options:
           When set to `all`, all server messages are cached.
           When set to `tagged`, only server messages with `_cache: true` are cached.
 
+      --cache-persist
+          Preserve server message history for room event after last client disconnects
+
       --delay <SECONDS>
           Delay before attaching to child [default: 1 for --tcp]
 

--- a/docs/man/cli.md
+++ b/docs/man/cli.md
@@ -34,8 +34,8 @@ Options:
           When set to `all`, all server messages are cached.
           When set to `tagged`, only server messages with `_cache: true` are cached.
 
-      --cache-persist
-          Preserve server message history for room event after last client disconnects
+      --cachepersist
+          Preserve server message history for room even after last client disconnects
 
       --delay <SECONDS>
           Delay before attaching to child [default: 1 for --tcp]

--- a/docs/man/cli.md
+++ b/docs/man/cli.md
@@ -26,6 +26,14 @@ Options:
   -b, --binary
           Set scalesocket to experimental binary mode
 
+      --cache <[TYPE:]SIZE>
+          Cache server message history for room and replay it to new clients
+          
+          The cache buffer retains the last <SIZE> chunks, determined by <TYPE>.
+          
+          When set to `all`, all server messages are cached.
+          When set to `tagged`, only server messages with `_cache: true` are cached.
+
       --delay <SECONDS>
           Delay before attaching to child [default: 1 for --tcp]
 

--- a/docs/man/navigation.yaml
+++ b/docs/man/navigation.yaml
@@ -9,6 +9,8 @@
     href: README.md#quick-start
   - label: Usage
     href: usage.md
+  - label: Advanced Usage
+    href: advanced_usage.md
   - label: Alternatives
     href: comparison.md
 - heading: Examples

--- a/docs/man/usage.md
+++ b/docs/man/usage.md
@@ -64,7 +64,7 @@ ScaleSocket can optionally send a message to the target when a client joins or l
 The messages support the variables:
 * `#ID` eg. `123`
 * `QUERY_XYZ` for each query parameter, `?xyz=`, in the connection URL.
-* The [Environment variables](#environment-variables)
+* The [Environment variables](/man/advanced_usage.md#environment-variables)
 
 For example, starting scalesocket with:
 
@@ -76,45 +76,6 @@ Sends the message `{"type":"Join","_from":123}` to the server when a new client 
 
 
 See the [CLI Reference](/man/cli.md) and the `--joinmsg` and `--leavemsg` arguments for details.
-
-## Environment Variables
-
-ScaleSocket can optionally expose CGI [environment variables](https://www.rfc-editor.org/rfc/rfc3875.html) to the target.
-
-
-The supported environment variables are:
-* `QUERY_STRING` eg. `foo=bar&baz=qux`
-* `REMOTE_ADDR` eg. `127.0.0.1:1234`
-* `ROOM` eg. `exampleroom`
-* `PORT` for binding in TCP mode
-* Any environment variables specified with `--passenv`
-
-See the [CLI Reference](/man/cli.md) and the `--passenv` argument for details.
-
-## Endpoints
-
-### Metrics Endpoint
-
-ScaleSocket can expose an [OpenMetrics](https://openmetrics.io/) and [Prometheus](https://prometheus.io/) compatible endpoint for scraping metrics.
-
-The tracked metrics are:
-* `scalesocket_websocket_connections` with the label `room`
-* `scalesocket_websocket_connections_total` with the label `room`
-
-See the [CLI Reference](/man/cli.md) and the `--metrics` flag for details.
-
-### Metadata Endpoint
-
-ScaleSocket can expose a JSON endpoint for retrieving rooms and their metadata.
-
-When `--framing` is set to JSON, additional metadata can be set by the server using messages with a `_meta: true` field.
-This is useful for building a lobby or room list.
-
-See the [CLI Reference](/man/cli.md) and the `--api` flag for details.
-
-### Health Endpoint
-
-ScaleSocket exposes a standard `/health` endpoint for checking readiness.
 
 ## Static File Hosting
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -98,7 +98,7 @@ impl Channel {
     pub fn write_sock(&mut self, msg: Bytes) {
         match deserialize(&msg, self.framing.process_to_socket()) {
             Ok(msg) => match msg {
-                (t, payload) if t.is_meta => {
+                (h, payload) if h.is_meta => {
                     let _ = self.event_tx.as_ref().expect("event_tx to be passed").send(
                         Event::ProcessMeta {
                             room: self.room.clone(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,6 +31,10 @@ pub struct Config {
     #[clap(long, value_parser = parse_cache, value_name = "[TYPE:]SIZE", verbatim_doc_comment)]
     pub cache: Option<Cache>,
 
+    #[clap(long = "cachepersist", action)]
+    /// Preserve server message history for room even after last client disconnects
+    pub cache_persist: bool,
+
     /// Delay before attaching to child [default: 1 for --tcp]
     #[clap(
         long = "delay",

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,11 +1,14 @@
 use {
+    futures::stream,
     futures::{future::ready, FutureExt, StreamExt, TryFutureExt, TryStreamExt},
     sender_sink::wrappers::UnboundedSenderSink,
     std::sync::Arc,
     tokio::sync::Barrier,
     tokio::try_join,
+    tokio_stream::wrappers::errors::BroadcastStreamRecvError,
     tokio_stream::wrappers::BroadcastStream,
     tracing::instrument,
+    warp::filters::ws::Message,
     warp::ws::WebSocket,
 };
 
@@ -23,13 +26,17 @@ pub async fn handle(
     proc_rx: FromProcessRx,
     proc_tx: ToProcessTx,
     barrier: Option<Arc<Barrier>>,
+    cache: Vec<(Header, Message)>,
 ) -> AppResult<()> {
     let proc_rx = BroadcastStream::new(proc_rx);
     let (sock_tx, sock_rx) = ws.split();
     tracing::debug!("connection handler listening to client");
 
-    // forward process to socket
-    let proc_to_sock = proc_rx
+    // forward process and cache to socket
+    let cache = cache.into_iter().map(Ok::<_, BroadcastStreamRecvError>);
+    let proc_rx_and_cache = stream::iter(cache).chain(proc_rx);
+
+    let proc_to_sock = proc_rx_and_cache
         .filter_map(|line| ready(line.ok()))
         .filter_map(|(id, msg)| {
             ready(match id {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -30,7 +30,7 @@ pub async fn handle(
 ) -> AppResult<()> {
     let proc_rx = BroadcastStream::new(proc_rx);
     let (sock_tx, sock_rx) = ws.split();
-    tracing::debug!("connection handler listening to client");
+    tracing::debug!("listening to client");
 
     // forward process and cache to socket
     let cache = cache.into_iter().map(Ok::<_, BroadcastStreamRecvError>);

--- a/src/events.rs
+++ b/src/events.rs
@@ -147,7 +147,7 @@ fn attach(
     };
 
     tokio::spawn(
-        connection::handle(*ws, conn, framing, proc_rx, proc_tx.clone(), barrier)
+        connection::handle(*ws, conn, framing, proc_rx, proc_tx.clone(), barrier, None)
             .then({
                 // NOTE: we invoke on_init closure immediately...
                 on_init();
@@ -172,7 +172,7 @@ fn spawn(
         tracing::debug!("reserved port {}", port);
     }
 
-    let mut proc = Channel::new(&state.cfg, port, room, env.cgi.clone());
+    let mut proc = Channel::new(&state.cfg, port, room, env.cgi.clone(), None);
     let senders = proc.take_senders();
     proc.give_sender(tx.clone());
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -271,6 +271,10 @@ fn exit(room: RoomID, code: Option<i32>, port: Option<PortID>, state: &mut State
         tracing::debug!("released port {}", port);
     }
 
+    if !state.cfg.cache_persist {
+        state.cache.remove(&room);
+    }
+
     if state.procs.contains_key(&room) {
         tracing::error!(room, code, "process exited");
         // TODO inform clients

--- a/src/events.rs
+++ b/src/events.rs
@@ -328,7 +328,7 @@ mod tests {
         let (proc_tx, proc_rx) = mpsc::unbounded_channel();
         let broadcast_tx = broadcast::Sender::new(16);
         let (kill_tx, _) = oneshot::channel();
-        let cache = CacheBuffer::new(&Cache::Messages(64));
+        let cache = CacheBuffer::new(&Cache::All(8));
         (proc_rx, (broadcast_tx, proc_tx, kill_tx), cache)
     }
 
@@ -413,7 +413,7 @@ mod tests {
         let mut state = State {
             conns: HashMap::new(),
             procs: HashMap::from([("room1".to_string(), senders)]),
-            cfg: create_config("scalesocket --cache=messages:64 --joinmsg=baz cat"),
+            cfg: create_config("scalesocket --cache=all:64 --joinmsg=baz cat"),
             ports: PortPool::new(),
             cache: HashMap::from([("room1".to_string(), Arc::new(Mutex::new(cache)))]),
         };

--- a/src/events.rs
+++ b/src/events.rs
@@ -3,6 +3,7 @@ use {
     id_pool::IdPool as PortPool,
     std::collections::{HashMap, HashSet},
     std::sync::Arc,
+    std::sync::Mutex,
     tokio::sync::Barrier,
     tracing::{instrument, Instrument},
     warp::ws::{Message, WebSocket},
@@ -16,15 +17,17 @@ use crate::{
     error::AppResult,
     metrics::Metrics,
     process,
-    types::{ConnID, Event, EventRx, EventTx, PortID, ProcessSenders, RoomID},
+    types::{CacheBuffer, ConnID, Event, EventRx, EventTx, PortID, ProcessSenders, RoomID},
     utils::new_conn_id,
 };
 
 type ConnectionMap = HashMap<RoomID, HashSet<ConnID>>;
 type ProcessMap = HashMap<RoomID, ProcessSenders>;
+type ProcessCacheMap = HashMap<RoomID, Arc<Mutex<CacheBuffer>>>;
 
 struct State {
     pub conns: ConnectionMap,
+    pub cache: ProcessCacheMap,
     pub procs: ProcessMap,
     pub ports: PortPool,
     pub cfg: Config,
@@ -94,6 +97,7 @@ impl State {
             conns: HashMap::new(),
             procs: HashMap::new(),
             ports: PortPool::new_ranged(cfg.tcpports.clone()),
+            cache: HashMap::new(),
             cfg,
         }
     }
@@ -114,6 +118,12 @@ fn attach(
     // Get process senders from map
     let (proc_tx_broadcast, proc_tx, _) = state.procs.get(&room).expect("room not in process map");
     let proc_rx = proc_tx_broadcast.subscribe();
+
+    // Clone process cache from map for minimal mutex contention
+    let cache = match state.cache.get(&room) {
+        Some(shared) => shared.lock().expect("poisoned lock").to_vec(),
+        None => Vec::new(),
+    };
 
     let mut on_init = || {
         // Store connection handle in map
@@ -147,7 +157,7 @@ fn attach(
     };
 
     tokio::spawn(
-        connection::handle(*ws, conn, framing, proc_rx, proc_tx.clone(), barrier, None)
+        connection::handle(*ws, conn, framing, proc_rx, proc_tx.clone(), barrier, cache)
             .then({
                 // NOTE: we invoke on_init closure immediately...
                 on_init();
@@ -172,7 +182,18 @@ fn spawn(
         tracing::debug!("reserved port {}", port);
     }
 
-    let mut proc = Channel::new(&state.cfg, port, room, env.cgi.clone(), None);
+    let cache = match state.cfg.cache {
+        Some(ref c) => {
+            state
+                .cache
+                .entry(room.to_string())
+                .or_insert_with(|| Arc::new(Mutex::new(CacheBuffer::new(c))));
+            state.cache.get(room).cloned()
+        }
+        None => None,
+    };
+
+    let mut proc = Channel::new(&state.cfg, port, room, env.cgi.clone(), cache);
     let senders = proc.take_senders();
     proc.give_sender(tx.clone());
 
@@ -269,7 +290,10 @@ fn shutdown(state: State) {
 #[cfg(test)]
 mod tests {
 
-    use std::collections::{HashMap, HashSet};
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::{Arc, Mutex},
+    };
 
     use clap::Parser;
     use tokio::sync::{
@@ -277,12 +301,12 @@ mod tests {
         mpsc::{self},
         oneshot,
     };
-    use warp::Filter;
+    use warp::{filters::ws::Message, Filter};
 
     use super::{attach, disconnect, Env, Event, PortPool, State};
     use crate::{
         cli::Config,
-        types::{ProcessSenders, ToProcessRx},
+        types::{Cache, CacheBuffer, ProcessSenders, ToProcessRx},
     };
 
     fn create_config(args: &'static str) -> Config {
@@ -300,7 +324,15 @@ mod tests {
         (proc_rx, (broadcast_tx, proc_tx, kill_tx))
     }
 
-    async fn create_ws() -> warp::ws::WebSocket {
+    fn create_process_with_cache() -> (ToProcessRx, ProcessSenders, CacheBuffer) {
+        let (proc_tx, proc_rx) = mpsc::unbounded_channel();
+        let broadcast_tx = broadcast::Sender::new(16);
+        let (kill_tx, _) = oneshot::channel();
+        let cache = CacheBuffer::new(&Cache::Messages(64));
+        (proc_rx, (broadcast_tx, proc_tx, kill_tx), cache)
+    }
+
+    async fn create_ws() -> (warp::ws::WebSocket, warp::test::WsClient) {
         // Use channel to move Websocket out of closure (but could use Arc<Mutex>>)
         let (tx, mut rx) = sync::mpsc::unbounded_channel();
 
@@ -313,10 +345,10 @@ mod tests {
             })
         });
 
-        let _ = warp::test::ws().handshake(route).await.expect("handshake");
+        let wsc = warp::test::ws().handshake(route).await.expect("handshake");
         let ws = rx.recv().await.unwrap();
 
-        ws
+        (ws, wsc)
     }
 
     #[tokio::test]
@@ -327,9 +359,10 @@ mod tests {
             procs: HashMap::from([("room1".to_string(), senders)]),
             cfg: create_config("scalesocket cat --joinmsg=foo"),
             ports: PortPool::new(),
+            cache: HashMap::new(),
         };
         let (tx, _) = sync::mpsc::unbounded_channel::<Event>();
-        let ws = create_ws().await;
+        let (ws, _) = create_ws().await;
 
         attach(
             "room1".to_string(),
@@ -351,9 +384,10 @@ mod tests {
             procs: HashMap::from([("room1".to_string(), senders)]),
             cfg: create_config("scalesocket cat --joinmsg=foo"),
             ports: PortPool::new(),
+            cache: HashMap::new(),
         };
         let (tx, _) = sync::mpsc::unbounded_channel::<Event>();
-        let ws = create_ws().await;
+        let (ws, _) = create_ws().await;
 
         attach(
             "room1".to_string(),
@@ -364,9 +398,39 @@ mod tests {
             None,
         );
 
-        let received_event = proc_rx.recv().await.unwrap();
-        let received_msg = std::str::from_utf8(&received_event.as_bytes()).unwrap();
+        let received_msg = proc_rx.recv().await.unwrap();
+        let received_msg = std::str::from_utf8(&received_msg.as_bytes()).unwrap();
         assert_eq!("foo", received_msg);
+    }
+
+    #[tokio::test]
+    async fn test_attach_sends_cache() {
+        let (_proc_rx, senders, mut cache) = create_process_with_cache();
+
+        cache.write(Message::text("foo"));
+        cache.write(Message::text("bar"));
+
+        let mut state = State {
+            conns: HashMap::new(),
+            procs: HashMap::from([("room1".to_string(), senders)]),
+            cfg: create_config("scalesocket --cache=messages:64 --joinmsg=baz cat"),
+            ports: PortPool::new(),
+            cache: HashMap::from([("room1".to_string(), Arc::new(Mutex::new(cache)))]),
+        };
+        let (tx, _) = sync::mpsc::unbounded_channel::<Event>();
+        let (ws, mut wsc) = create_ws().await;
+
+        attach(
+            "room1".to_string(),
+            Env::default(),
+            Box::new(ws),
+            &tx,
+            &mut state,
+            None,
+        );
+
+        assert_eq!(wsc.recv().await.unwrap(), Message::text("foo"));
+        assert_eq!(wsc.recv().await.unwrap(), Message::text("bar"));
     }
 
     #[tokio::test]
@@ -379,6 +443,7 @@ mod tests {
             procs: HashMap::from([("room1".to_string(), create_process_senders())]),
             cfg: create_config("scalesocket cat"),
             ports: PortPool::new(),
+            cache: HashMap::new(),
         };
 
         disconnect("room1".to_string(), Env::default(), 1, &mut state);

--- a/src/process.rs
+++ b/src/process.rs
@@ -24,14 +24,14 @@ use crate::{
 
 #[instrument(parent = None, name = "process", skip_all)]
 pub async fn handle(mut channel: Channel, barrier: Option<Arc<Barrier>>) -> AppResult<Option<i32>> {
-    if let Some(barrier) = barrier.clone() {
+    if let Some(barrier) = barrier {
         barrier.wait().await;
         tracing::debug!("waited for connection");
     }
     let mut proc = spawn(&mut channel).await?;
     let mut child = proc.child.take().unwrap();
 
-    tracing::debug!("process handler listening to child");
+    tracing::debug!("listening to child");
 
     let exit_code = loop {
         tokio::select! {

--- a/src/process.rs
+++ b/src/process.rs
@@ -198,7 +198,7 @@ mod tests {
 
     fn create_channel(args: &'static str) -> Channel {
         let config = Config::parse_from(args.split_whitespace());
-        Channel::new(&config, None, "room1", CGIEnv::default())
+        Channel::new(&config, None, "room1", CGIEnv::default(), None)
     }
 
     fn create_channel_with_event_tx(args: &'static str, event_tx: EventTx) -> Channel {

--- a/src/process.rs
+++ b/src/process.rs
@@ -167,6 +167,7 @@ struct RunningProcess {
 }
 
 impl RunningProcess {
+    /// Send a message to the child process
     pub async fn write_child(&mut self, msg: Message, is_binary: bool) -> IOResult<()> {
         if is_binary {
             self.proc_tx.write_all(msg.as_bytes()).await

--- a/src/types.rs
+++ b/src/types.rs
@@ -115,6 +115,11 @@ pub enum Log {
     Text,
 }
 
+#[derive(Debug, Clone)]
+pub enum Cache {
+    Messages(usize),
+}
+
 // Channel for app events
 pub type EventTx = mpsc::UnboundedSender<Event>;
 pub type EventRx = mpsc::UnboundedReceiver<Event>;

--- a/src/types.rs
+++ b/src/types.rs
@@ -20,6 +20,8 @@ pub struct Header {
     pub to: Option<ConnID>,
     #[serde(rename = "_meta", default = "bool::default")]
     pub is_meta: bool,
+    #[serde(rename = "_cache", default = "bool::default")]
+    pub is_cache: bool,
 }
 
 impl Header {
@@ -27,6 +29,7 @@ impl Header {
         Header {
             to: Some(to),
             is_meta: false,
+            is_cache: false,
         }
     }
 
@@ -34,6 +37,7 @@ impl Header {
         Header {
             to: None,
             is_meta: false,
+            is_cache: false,
         }
     }
 }
@@ -118,7 +122,36 @@ pub enum Log {
 
 #[derive(Debug, Clone)]
 pub enum Cache {
-    Messages(usize),
+    All(usize),
+    Tagged(usize),
+}
+
+/// Outgoing caching for a channel
+#[derive(Debug, Clone)]
+pub enum Caching {
+    None,
+    All,
+    Tagged,
+}
+
+impl Caching {
+    pub fn matches(&self, h: &Header) -> bool {
+        match self {
+            Self::All => true,
+            Self::Tagged if h.is_cache => true,
+            _ => false,
+        }
+    }
+}
+
+impl From<&Config> for Caching {
+    fn from(cfg: &Config) -> Self {
+        match cfg.cache {
+            Some(Cache::All(_)) => Self::All,
+            Some(Cache::Tagged(_)) => Self::Tagged,
+            None => Self::None,
+        }
+    }
 }
 
 pub type BoxedHistoryBuffer<T, const N: usize> = Box<HistoryBuffer<T, N>>;
@@ -133,10 +166,11 @@ pub enum CacheBuffer {
 
 impl CacheBuffer {
     pub fn new(cache: &Cache) -> Self {
+        use Cache::*;
         match cache {
-            Cache::Messages(1) => Self::Single(HistoryBuffer::<_, 1>::new()),
-            Cache::Messages(8) => Self::Tiny(HistoryBuffer::<_, 8>::new()),
-            Cache::Messages(64) => Self::Small(Box::new(HistoryBuffer::<_, 64>::new())),
+            All(1) | Tagged(1) => Self::Single(HistoryBuffer::<_, 1>::new()),
+            All(8) | Tagged(8) => Self::Tiny(HistoryBuffer::<_, 8>::new()),
+            All(64) | Tagged(64) => Self::Small(Box::new(HistoryBuffer::<_, 64>::new())),
             _ => panic!("invalid cache size"),
         }
     }


### PR DESCRIPTION
* Add `--cache=[TYPE:]SIZE` argument for enabling caching of server messages.
  * An experimental feature useful for sending "chat history" or "state" to new clients upon joining.
  * Valid types are `all` and `tagged`. Valid sizes are `1`,`8` and `64` (as of now).
  * In `tagged` mode, when `--framing` is set to JSON, only messages with a `_cache: true` field will be cached.
* Add `--cachepersist` argument for retaining cache even after last client has disconnected.
* Update docs.