### PR TITLE
Feature: delimiters

### DIFF
--- a/docs/man/advanced_usage.md
+++ b/docs/man/advanced_usage.md
@@ -39,6 +39,15 @@ See the [CLI Reference](/man/cli.md) and the `--api` flag for details.
 
 ScaleSocket exposes a standard `/health` endpoint for checking readiness.
 
+## Delimiters
+
+ScaleSocket parses output intpo messages by splitting output at newline (`\n`), except when `--binary` mode is enabled.
+
+To alter this behaviour, the `--delimiters` argument can be used to specify a set of custom delimiters.
+For example `--delimiters=,` will split comma-separated output by the target into messages.
+
+To set the delimiter to the null-byte (`\0`), use `--null`. This is useful for outputting multiline messages from the target, for example as a backend for [htmx](https://htmx.org/).
+
 ## Caching
 
 ScaleSocket can optionally cache server sent messages, and send them to new clients when they join a room.

--- a/docs/man/cli.md
+++ b/docs/man/cli.md
@@ -40,6 +40,13 @@ Options:
       --delay <SECONDS>
           Delay before attaching to child [default: 1 for --tcp]
 
+      --delimiters=<DELIMITERS>
+          Process output items are terminated by given characters
+          
+          See --null for null termination.
+          
+          [default: "/n"]
+
       --joinmsg <MSG>
           Emit message to child on client connect (use #ID for id)
 

--- a/docs/man/cli.md
+++ b/docs/man/cli.md
@@ -66,6 +66,9 @@ Options:
       --metrics
           Expose OpenMetrics endpoint at /metrics
 
+      --null
+          Process output items are terminated by a null character
+
       --oneshot
           Serve only once
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -24,6 +24,7 @@ pub struct Channel {
     pub source: Option<Source>,
     pub room: RoomID,
     pub is_binary: bool,
+    pub delimiters: String,
     pub attach_delay: Option<u64>,
     pub framing: Framing,
     pub caching: Caching,
@@ -69,11 +70,14 @@ impl Channel {
             false => Some(Source::Stdio(Command::new(cmd))),
         };
 
+        let mut delimiters = config.delimiters.clone().unwrap_or_default();
+
         Self {
             source,
             is_binary: config.binary,
             room: room.to_string(),
             attach_delay: config.delay,
+            delimiters,
             framing: config.into(),
             caching: config.into(),
             tx,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -71,6 +71,9 @@ impl Channel {
         };
 
         let mut delimiters = config.delimiters.clone().unwrap_or_default();
+        if config.null {
+            delimiters.push('\0');
+        }
 
         Self {
             source,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,12 +44,15 @@ pub struct Config {
     pub delay: Option<u64>,
 
     /// Process output items are terminated by given characters
+    ///
+    /// See --null for null termination.
     #[clap(
         long,
         value_parser,
         value_name = "DELIMITERS",
         default_value = "\n",
         default_value_if("binary", ArgPredicate::Equals("true".into()), Some("")),
+        default_value_if("null", ArgPredicate::Equals("true".into()), Some("")),
         require_equals = true,
         conflicts_with = "binary",
     )]
@@ -101,6 +104,10 @@ pub struct Config {
     /// Expose OpenMetrics endpoint at /metrics
     #[clap(long, action)]
     pub metrics: bool,
+
+    /// Process output items are terminated by a null character
+    #[clap(long, action)]
+    pub null: bool,
 
     /// Serve only once.
     #[clap(long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,6 +43,18 @@ pub struct Config {
     )]
     pub delay: Option<u64>,
 
+    /// Process output items are terminated by given characters
+    #[clap(
+        long,
+        value_parser,
+        value_name = "DELIMITERS",
+        default_value = "\n",
+        default_value_if("binary", ArgPredicate::Equals("true".into()), Some("")),
+        require_equals = true,
+        conflicts_with = "binary",
+    )]
+    pub delimiters: Option<String>,
+
     /// Emit message to child on client connect (use #ID for id)
     #[clap(
         long,

--- a/src/process.rs
+++ b/src/process.rs
@@ -292,6 +292,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_handle_process_output_delimiters_null() {
+        let channel = create_channel("scalesocket --null printf -- foo\\0bar");
+        let mut proc_rx = channel.cast_tx.subscribe();
+
+        handle(channel, None).await.ok();
+        let output = proc_rx.recv().await.ok();
+
+        assert_eq!(output, Some(Message::text("foo").broadcast()));
+    }
+
+    #[tokio::test]
     async fn test_handle_process_output_framed_json() {
         let channel = create_channel(r#"scalesocket --frame echo -- {"_to": 0}"#);
         let mut proc_rx = channel.cast_tx.subscribe();


### PR DESCRIPTION
* Add `--delimiters` argument for specifying delimiters for process output.
  * Process output is split into messages based on these.
  * Default value is newline (`\n`) for line mode.
* Add `--null` flag for enabling null-terminated mode.
  * if combined with `--delimiters`, null (`\n`) is added to set of delimiters.